### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-macos-intel:
     runs-on: macos-13


### PR DESCRIPTION
Potential fix for [https://github.com/jose-rZM/SyntaxTutor/security/code-scanning/1](https://github.com/jose-rZM/SyntaxTutor/security/code-scanning/1)

To fix the issue, we will add an explicit `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow primarily involves building and packaging an application, it does not require write permissions. The minimal permission `contents: read` will be set to restrict access to repository contents to read-only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
